### PR TITLE
Fix jquery scope once again, in integration test 🔨

### DIFF
--- a/tests/integration/shadow-dom-test.js
+++ b/tests/integration/shadow-dom-test.js
@@ -16,6 +16,6 @@ test('Uses native Shadow DOM if available', function(assert) {
 
   assert.ok(document.querySelector('paper-button').shadowRoot,
     'paper-button has shadowRoot');
-  assert.equal(this.$('paper-button').attr('role'), 'button',
+  assert.equal($('paper-button').attr('role'), 'button',
     'role is attached to button immediately');
 });


### PR DESCRIPTION
For some reason ember 2.9.0 and above has some serious problems with
the previously used scope. This should fix a broken build.