### PR TITLE
fix(scraper): Add check for pkg existance.

### DIFF
--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -6,7 +6,7 @@ const path = require('path');
 
 exports.isWebComponent = (pkg) => {
   let { keywords, main } = pkg;
-  let hasAnyKeyword = keywords && (keywords.includes('web-component') || 
+  let hasAnyKeyword = keywords && (keywords.includes('web-component') ||
                                    keywords.includes('web-components'));
   let hasEntryPoint = main && main.includes(`${pkg.name}.html`);
   // TODO has package `webcomponents.org published` badge
@@ -17,15 +17,20 @@ exports.isWebComponent = (pkg) => {
 exports.scrapeDeps = (deps, dir, pkgFilename) =>
   Object.keys(deps).reduce((stack, name) => {
     let elementPath = path.join(dir, name, `${name}.html`);
-    let pkg = require(path.join(dir, name, pkgFilename));
-    // ⚠️ FIXME Use npm module 'resolve' for this instead: more reliable.
-    // @see https://github.com/ember-cli/ember-cli-version-checker/blob/master/src/npm-dependency-version-checker.js
+    let pkgPath = path.join(dir, name, pkgFilename);
 
-    // verify whether webcomponent and entrypoint existance
-    if (exports.isWebComponent(pkg) && fileExists(elementPath)) {
-      let allPath = path.join(dir, name, 'all-imports.html');
-      elementPath = fileExists(allPath) ? allPath : elementPath;
-      stack.push({ name, elementPath });
+    // check for pkg existance - some 3rd party dependencies don't have it (ex. blueimp-canvas-to-blob)
+    if (fileExists(pkgPath)) {
+      let pkg = require(pkgPath);
+      // ⚠️ FIXME Use npm module 'resolve' for this instead: more reliable.
+      // @see https://github.com/ember-cli/ember-cli-version-checker/blob/master/src/npm-dependency-version-checker.js
+
+      // verify whether webcomponent and entrypoint existance
+      if (exports.isWebComponent(pkg) && fileExists(elementPath)) {
+        let allPath = path.join(dir, name, 'all-imports.html');
+        elementPath = fileExists(allPath) ? allPath : elementPath;
+        stack.push({ name, elementPath });
+      }
     }
 
     return stack;

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -5,13 +5,16 @@ const fileExists = fs.existsSync;
 const path = require('path');
 
 exports.isWebComponent = (pkg) => {
-  let { keywords, main } = pkg;
+  let {
+    keywords,
+    main
+  } = pkg;
   let hasAnyKeyword = keywords && (keywords.includes('web-component') ||
-                                   keywords.includes('web-components'));
+    keywords.includes('web-components'));
   let hasEntryPoint = main && main.includes(`${pkg.name}.html`);
   // TODO has package `webcomponents.org published` badge
 
-  return [ hasAnyKeyword, hasEntryPoint ].some(t => t);
+  return [hasAnyKeyword, hasEntryPoint].some(t => t);
 };
 
 exports.scrapeDeps = (deps, dir, pkgFilename) =>
@@ -19,18 +22,21 @@ exports.scrapeDeps = (deps, dir, pkgFilename) =>
     let elementPath = path.join(dir, name, `${name}.html`);
     let pkgPath = path.join(dir, name, pkgFilename);
 
-    // check for pkg existance - some 3rd party dependencies don't have it (ex. blueimp-canvas-to-blob)
-    if (fileExists(pkgPath)) {
-      let pkg = require(pkgPath);
-      // ⚠️ FIXME Use npm module 'resolve' for this instead: more reliable.
-      // @see https://github.com/ember-cli/ember-cli-version-checker/blob/master/src/npm-dependency-version-checker.js
+    // fail softly for the rare case where project has no package file defined
+    if (!fileExists(pkgPath)) return stack;
 
-      // verify whether webcomponent and entrypoint existance
-      if (exports.isWebComponent(pkg) && fileExists(elementPath)) {
-        let allPath = path.join(dir, name, 'all-imports.html');
-        elementPath = fileExists(allPath) ? allPath : elementPath;
-        stack.push({ name, elementPath });
-      }
+    // ⚠️ FIXME Use npm module 'resolve' for this instead: more reliable.
+    // @see https://github.com/ember-cli/ember-cli-version-checker/blob/master/src/npm-dependency-version-checker.js
+    let pkg = require(pkgPath);
+
+    // verify whether webcomponent and entrypoint existance
+    if (exports.isWebComponent(pkg) && fileExists(elementPath)) {
+      let allPath = path.join(dir, name, 'all-imports.html');
+      elementPath = fileExists(allPath) ? allPath : elementPath;
+      stack.push({
+        name,
+        elementPath
+      });
     }
 
     return stack;


### PR DESCRIPTION
- Add check for pkgPath existance - some 3rd party dependencies don't have it (ex. blueimp-canvas-to-blob) and make the build process crash.

